### PR TITLE
Fix parseMarkdown 

### DIFF
--- a/ai-driven-dev-prompts/_manifest.yml
+++ b/ai-driven-dev-prompts/_manifest.yml
@@ -1,6 +1,6 @@
 name: 'ai-driven-dev-prompts'
 title: 'AI Driven Dev Prompts'
 description: The best collection of prompts for developers.
-version: 0.3.28
+version: 0.3.29
 author: alexsoyes
 website: https://alexsoyes.com

--- a/ai-driven-dev-prompts/package.yml
+++ b/ai-driven-dev-prompts/package.yml
@@ -4,10 +4,21 @@ preserve_clipboard: false
 matches:
   - trigger: ':codeCodingHelpThinking'
     form: |
-      Provide an example of the usage of this function, input and output.
+      I need you to help me think about the best way to implement this new functionality:
+      [[new_functionality]]
+
+      Please provide the best coding steps regarding my existing code.
     form_fields:
       new_functionality:
         multiline: true
+  - trigger: ':codeCodingImproveReadability'
+    form: |
+      I need you to improve the readability of the following code.
+
+      Result should remain the same, but the code should be easier to read and understand.
+  - trigger: ':codeCodingProvideExampleUsage'
+    form: |
+      Provide an example of the usage of this function, input and output.
   - trigger: ':codeCodingDetectInconsistencies'
     form: |
       I need you to detect inconsistencies in the code.
@@ -184,10 +195,27 @@ matches:
         multiline: true
   - trigger: ':instructExistingFeatureAcknowledgements'
     form: |
-      Give me an output example based on your understandings, with required inputs and the expected output.
+      Here are the specifications of the feature I need to code (surrounded by "---" delimiters).
+
+      Now, can you:
+
+      1. Acknowledge it
+      2. Reformulate in bullet point grouped by section to show me that you understood what to do
+      3. Generate development steps (based on an existing projet you do not know nothing about)
+
+      Finally, ask me the relevant questions about implementing the feature in my project regarding my project's tech stack and libraries.
+
+      Ask anything you need to know, like existing code, libraries, mockups available, logics, etc.
+
+      ---
+      [[copy_and_paste_the_specifications_here]]
+      ---
     form_fields:
       copy_and_paste_the_specifications_here:
         multiline: true
+  - trigger: ':instructExistingFeatureOutputExample'
+    form: |
+      Give me an output example based on your understandings, with required inputs and the expected output.
   - trigger: ':instructExistingFeatureIterate'
     form: |
       Here are some answers about your previous questions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-driven-dev-community",
-  "version": "0.3.28",
+  "version": "0.3.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-driven-dev-community",
-      "version": "0.3.28",
+      "version": "0.3.29",
       "dependencies": {
         "markdown-it": "^14.0.0",
         "yaml": "^2.3.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-driven-dev-community",
-  "version": "0.3.28",
+  "version": "0.3.29",
   "description": "From prompts in Readme to Espanso text expander!",
   "main": "index.js",
   "directories": {

--- a/src/espanso-generation/__snapshots__/parseMarkdown.test.js.snap
+++ b/src/espanso-generation/__snapshots__/parseMarkdown.test.js.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`parseMarkdown should accept trigger headings ending with (WIP) 1`] = `
+[
+  {
+    "choices": {},
+    "form": "I need you to help me think about the best way to implement this new functionality:
+[[new_functionality]]
+
+Please provide the best coding steps regarding my existing code.
+",
+    "trigger": "codeCodingHelpThinking",
+    "variables": [
+      "new_functionality",
+    ],
+  },
+  {
+    "choices": {},
+    "form": "I need you to improve the readability of the following code.
+
+Result should remain the same, but the code should be easier to read and understand.
+",
+    "trigger": "codeCodingImproveReadability",
+    "variables": [],
+  },
+  {
+    "choices": {},
+    "form": "Provide an example of the usage of this function, input and output.
+",
+    "trigger": "codeCodingProvideExampleUsage",
+    "variables": [],
+  },
+]
+`;

--- a/src/espanso-generation/parseMarkdown.test.js
+++ b/src/espanso-generation/parseMarkdown.test.js
@@ -56,4 +56,33 @@ I am a senior software engineer on JavaScript but I prefer to use TypeScript.
       },
     ]);
   });
+
+  it('should accept trigger headings ending with (WIP)', () => {
+    const markdownText = `
+### Help me thinking \`:codeCodingHelpThinking\`
+
+\`\`\`text
+I need you to help me think about the best way to implement this new functionality:
+[[new functionality]]
+
+Please provide the best coding steps regarding my existing code.
+\`\`\`
+
+### Improve code readability \`:codeCodingImproveReadability\` (WIP 🚧)
+
+\`\`\`text
+I need you to improve the readability of the following code.
+
+Result should remain the same, but the code should be easier to read and understand.
+\`\`\`
+
+### Give me an example of the usage of this function \`:codeCodingProvideExampleUsage\` (WIP 🚧)
+
+\`\`\`text
+Provide an example of the usage of this function, input and output.
+\`\`\`
+`;
+    expect(parseMarkdown(markdownText)).toMatchSnapshot();
+  });
 });
+


### PR DESCRIPTION
Hello Alex ! 

Petit correctif par rapport à `parseMarkdown` qui pouvait étrangement skip certaines parties.

Root cause : les "(WIP)" en fin de headings 😅 

J'ai simplement mis à jour le `match` et j'en ai profité pour modifier légèrement le fichier en proposant de passer par `triggerKey` plutôt qu'en mutant `currentTrigger` (ce genre de mutation rend les choses un peu moins lisibles).

D'ordinaire, je ne suis pas fan des snapshots pour les tests. Mais dans le cas de transformers (comme ici markdown vers yml) je trouve que c'est une façon simple et efficace d'identifier et de corriger un problème dans le parsing. 

Le fait que ça catch le moindre changement de caractère est plutôt une bonne chose pour ce type de features.